### PR TITLE
feat: 초기 entity 설계

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.4'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.flywaydb.flyway' version '10.15.0'
 }
 
 group = 'com.example'
@@ -24,7 +25,7 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -36,6 +37,14 @@ dependencies {
 
 	// WebDriverManager (ChromeDriver 자동 다운로드 및 관리)
 	implementation 'io.github.bonigarcia:webdrivermanager:5.7.0'
+
+	// Database Migration
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-mysql'
+
+	// Database
+	implementation 'mysql:mysql-connector-java:8.0.33'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	// Database
 	implementation 'mysql:mysql-connector-java:8.0.33'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/GOLDNet/domain/JobApplication.java
+++ b/src/main/java/com/example/GOLDNet/domain/JobApplication.java
@@ -1,0 +1,33 @@
+package com.example.GOLDNet.domain;
+
+import com.example.GOLDNet.global.enums.ApplicationStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "job_applications")
+public class JobApplication {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "application_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private LocalDate applicationDate;
+
+    @Column(length = 100, nullable = false)
+    private String companyName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ApplicationStatus status; //지원서 접수, 서류 검토 중, 불합격, 최종 합격
+}

--- a/src/main/java/com/example/GOLDNet/domain/JobPosting.java
+++ b/src/main/java/com/example/GOLDNet/domain/JobPosting.java
@@ -1,0 +1,61 @@
+package com.example.GOLDNet.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "job_postings")
+public class JobPosting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "job_posting_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String category;
+
+    @Column(length = 100)
+    private String salaryInfo;
+
+    private String location;
+
+    @Column(length = 50)
+    private String preferredAgeGroup;
+
+    @OneToMany(mappedBy = "jobPosting", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SavedJobPosting> savedJobPostings = new ArrayList<>();
+
+    // --- 근무 조건 ---
+    @Column(length = 100)
+    private String industry; //업직종
+
+    @Column(length = 100)
+    private String brandName; //브랜드
+
+    @Column(length = 50)
+    private String workDays; //근무요일
+
+    @Column(length = 50)
+    private String workHours; //근무시간
+
+    // --- 모집 조건 ---
+    @Lob
+    private String recruitmentConditions; //모집 조건
+
+    @Column(length = 100)
+    private String workRegion; //근무 지역
+
+    @Lob
+    private String detailedDescription; //상세 요강
+}

--- a/src/main/java/com/example/GOLDNet/domain/Member.java
+++ b/src/main/java/com/example/GOLDNet/domain/Member.java
@@ -1,0 +1,35 @@
+package com.example.GOLDNet.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "members")
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDate createdAt = LocalDate.now();
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Resume resume;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<JobApplication> applications = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SavedJobPosting> savedJobPostings = new ArrayList<>();
+
+}

--- a/src/main/java/com/example/GOLDNet/domain/Resume.java
+++ b/src/main/java/com/example/GOLDNet/domain/Resume.java
@@ -1,0 +1,49 @@
+package com.example.GOLDNet.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "resumes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Resume {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "resume_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(length = 255)
+    private String education; //학력
+
+    @Lob
+    private String experience; //경험
+
+    @Lob
+    private String preferredConditions; //희망 근무 조건
+
+    @Lob
+    private String selfIntroduction; //자기소개
+
+    @Lob
+    private String skills; //스킬 (지게차 운전, 재고 관리 시스템 사용 )
+
+    @Lob
+    private String strengths; //성격 강점
+
+    @Column(length = 10)
+    private String mbti;
+
+    @Lob
+    private String licensesAbilities; //자등증
+
+    @Lob
+    private String portfolioUrls; //포트폴리오
+
+    @Column(length = 255)
+    private String preferentialTreatment; //취업 우대사항(국가유공자 자녀 등)
+}

--- a/src/main/java/com/example/GOLDNet/domain/SavedJobPosting.java
+++ b/src/main/java/com/example/GOLDNet/domain/SavedJobPosting.java
@@ -1,0 +1,29 @@
+package com.example.GOLDNet.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "saved_job_postings")
+public class SavedJobPosting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "saved_job_posting_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_posting_id", nullable = false)
+    private JobPosting jobPosting;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDate createdAt = LocalDate.now();
+}

--- a/src/main/java/com/example/GOLDNet/global/enums/ApplicationStatus.java
+++ b/src/main/java/com/example/GOLDNet/global/enums/ApplicationStatus.java
@@ -1,0 +1,8 @@
+package com.example.GOLDNet.global.enums;
+
+public enum ApplicationStatus {
+    SUBMITTED,     // 지원서 접수
+    REVIEWING,     // 서류 검토 중
+    REJECTED,      // 불합격
+    ACCEPTED       // 최종 합격
+}

--- a/src/main/java/com/example/GOLDNet/service/CrawlerService.java
+++ b/src/main/java/com/example/GOLDNet/service/CrawlerService.java
@@ -70,7 +70,7 @@ public class CrawlerService {
                     liList = driver.findElements(By.cssSelector("ul#rsList02 > li"));
                     if (liList.isEmpty()) {
                         System.out.println(gu + " - 게시글 없음 (재조회 후)");
-                        break; // 리스트가 비어있으면 루프를 종료합니다.
+                        break; // 리스트가 비어있으면 루프를 종료
                     }
 
                     WebElement li = liList.get(i);
@@ -94,15 +94,15 @@ public class CrawlerService {
                                 ExpectedConditions.visibilityOfElementLocated(By.cssSelector("div.tbl-th"))
                         );
 
-                        // 상세 페이지 내의 모든 'tbl-view' 요소를 리스트로 찾습니다.
+                        // 상세 페이지 내의 모든 'tbl-view' 요소를 리스트로 찾기
                         List<WebElement> tblViewList = driver.findElements(By.cssSelector("div.tbl-view"));
 
-                        // 각 'tbl-view' 요소의 내용을 순회하며 가져옵니다.
+                        // 각 'tbl-view' 요소의 내용을 순회하며 가져옴
                         for (WebElement tblView : tblViewList) {
                             String tblViewText = tblView.getText();
                             System.out.println("상세 내용:\n" + tblViewText);
 
-                            // 크롤링 데이터를 저장합니다.
+                            // 크롤링 데이터를 저장
                             Map<String, String> jobInfo = new HashMap<>();
                             jobInfo.put("구", gu);
                             jobInfo.put("상세내용", tblViewText);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,78 @@
+spring:
+  profiles:
+    active: local # 기본 active profile 설정
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  datasource:
+    url: ${LOCAL_MYSQL_URL}
+    username: ${LOCAL_MYSQL_USER}
+    password: ${LOCAL_MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  sql:
+    init:
+      mode: always
+  jpa:
+    hibernate:
+      # 데이터베이스의 스키마와 jpa 엔티티가 불일치할때 애플리케이션 실행 중단
+      ddl-auto: validate
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    properties:
+      hibernate:
+        show-sql: true
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    #마이그레이션 파일 경로
+    locations: classpath:db/migration
+
+#
+#openai:
+#  api:
+#    key: ${OPENAI_API_KEY}
+#    url: ${OPENAI_API_URL}
+#  model: ${OPENAI_API_MODEL}
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    url: ${MYSQL_URL}
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  sql:
+    init:
+      mode: never
+  jpa:
+    hibernate:
+      # 데이터베이스의 스키마와 jpa 엔티티가 불일치할때 애플리케이션 실행 중단
+      ddl-auto: validate
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        show-sql: true
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    #마이그레이션 파일 경로
+    locations: classpath:db/migration
+
+#
+#openai:
+#  api:
+#    key: ${OPENAI_API_KEY}
+#    url: ${OPENAI_API_URL}
+#  model: ${OPENAI_API_MODEL}

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,72 @@
+create table members
+(
+    created_at date         not null,
+    member_id  bigint auto_increment
+        primary key,
+    name       varchar(255) not null
+);
+
+create table job_postings
+(
+    job_posting_id        bigint auto_increment
+        primary key,
+    preferredAgeGroup     varchar(50)  null,
+    workDays              varchar(50)  null,
+    workHours             varchar(50)  null,
+    brandName             varchar(100) null,
+    industry              varchar(100) null,
+    salaryInfo            varchar(100) null,
+    workRegion            varchar(100) null,
+    category              varchar(255) not null,
+    location              varchar(255) null,
+    title                 varchar(255) not null,
+    detailedDescription   longtext     null,
+    recruitmentConditions longtext     null
+);
+
+create table job_applications
+(
+    applicationDate date                                                    not null,
+    application_id  bigint auto_increment
+        primary key,
+    member_id       bigint                                                  not null,
+    companyName     varchar(100)                                            not null,
+    status          enum ('ACCEPTED', 'REJECTED', 'REVIEWING', 'SUBMITTED') not null,
+    constraint FKfstedvlyjmgg0aajakil7oqn2
+        foreign key (member_id) references goldnet.members (member_id)
+);
+
+
+create table resumes
+(
+    member_id             bigint       not null,
+    resume_id             bigint auto_increment
+        primary key,
+    mbti                  varchar(10)  null,
+    education             varchar(255) null,
+    preferentialTreatment varchar(255) null,
+    experience            longtext     null,
+    licensesAbilities     longtext     null,
+    portfolioUrls         longtext     null,
+    preferredConditions   longtext     null,
+    selfIntroduction      longtext     null,
+    skills                longtext     null,
+    strengths             longtext     null,
+    constraint UKp3p6k5m26935qawlrxsrx0722
+        unique (member_id),
+    constraint FKh7davpmtehs7xhuiwb3aetfvn
+        foreign key (member_id) references goldnet.members (member_id)
+);
+
+create table saved_job_postings
+(
+    created_at           date   not null,
+    job_posting_id       bigint not null,
+    member_id            bigint not null,
+    saved_job_posting_id bigint auto_increment
+        primary key,
+    constraint FKa4fuy0o2rvxnxkjil9b53f3nw
+        foreign key (job_posting_id) references goldnet.job_postings (job_posting_id),
+    constraint FKrkq3698k64jiw0kxqj521ryga
+        foreign key (member_id) references goldnet.members (member_id)
+);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: test
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+  flyway:
+    enabled: false


### PR DESCRIPTION
## Desc
### 1. Flyway 도입 
Flyway는 데이터베이스 마이그레이션 도구이다. SQL 스크립트를 통해 데이터베이스 스키마의 버전을 관리(형상 관리)할 수 있게 해준다.

도입 이유:
- 스키마 형상 관리: V1__init.sql과 같이 버전이 명명된 SQL 파일로 스키마 변경 이력을 코드처럼 관리 가능
- 개발 환경 통일: 모든 팀원이 동일한 DB 스키마를 유지할 수 있으며, 수동으로 DB를 수정하다 발생하는 실수를 방지
- 자동화: 애플리케이션 실행 시 스키마가 최신 버전으로 자동 업데이트되므로 배포 과정 단순

동작 방식:
1. 애플리케이션 시작 시 `src/main/resources/db/migration` 경로의 SQL 파일들을 확인
2. `flyway_schema_history` 테이블과 비교하여 아직 실행되지 않은 버전의 스크립트를 순서대로 실행
3. 이번 PR에서는 초기 테이블 전체를 생성하는 `V1__init.sql` 스크립트를 추가

### 2. 테이블 설계 
초기 서비스에 필요한 핵심 테이블 5개를 설계

`members`
설명: 서비스의 핵심 주체인 사용자 정보를 저장하는 테이블
주요 컬럼: member_id (PK), name

`resumes`
설명: 사용자의 이력서 정보(학력, 경력, 스킬 등)를 관리
관계: members 테이블과 1:1 관계를 가짐. (member_id를 FK로 사용)

`job_postings`
설명: 기업이 등록하는 채용 공고 정보를 저장하는 테이블
주요 컬럼: job_posting_id (PK), title, location, salary_info 등

`job_applications`
설명: 사용자의 채용 지원 현황을 기록
관계: 어떤 사용자(member_id)가 어떤 공고(job_posting_id)에 지원했는지 매핑하는 N:1 관계의 중심 테이블

주요 컬럼: application_id (PK), member_id (FK), job_posting_id (FK), status

`saved_job_postings`
설명: 사용자가 관심 있는 공고를 **저장(스크랩)**
관계: members와 job_postings의 N:M 관계를 해소하기 위한 중간 테이블
주요 컬럼: saved_job_posting_id (PK), member_id (FK), job_posting_id (FK)