### PR TITLE
feat: jobPostings 불러오는 api

### DIFF
--- a/src/main/java/com/example/GOLDNet/controller/JobsController.java
+++ b/src/main/java/com/example/GOLDNet/controller/JobsController.java
@@ -1,5 +1,7 @@
 package com.example.GOLDNet.controller;
 
+import com.example.GOLDNet.domain.JobPosting;
+import com.example.GOLDNet.dto.JobPostingResponse;
 import com.example.GOLDNet.service.CrawlerService;
 import com.example.GOLDNet.service.JobPostingService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -7,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -14,14 +17,14 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/postings")
 public class JobsController {
     private final CrawlerService crawlerService;
     private final JobPostingService jobPostingService;
     private final ObjectMapper objectMapper;
 
-    @GetMapping("/crawl-jobs")
+    @GetMapping("/crawl")
     public List<Map<String, String>> crawlJobs() {
-//        System.out.println(crawlerService.crawlJobs());
         return crawlerService.crawlJobs();
     }
 
@@ -41,5 +44,10 @@ public class JobsController {
             e.printStackTrace();
             return ResponseEntity.internalServerError().body("An error occurred: " + e.getMessage());
         }
+    }
+
+    @GetMapping
+    public ResponseEntity<List<JobPostingResponse>> getJobPostings(){
+        return ResponseEntity.ok(jobPostingService.getJobPostings());
     }
 }

--- a/src/main/java/com/example/GOLDNet/dto/JobPostingResponse.java
+++ b/src/main/java/com/example/GOLDNet/dto/JobPostingResponse.java
@@ -1,0 +1,18 @@
+package com.example.GOLDNet.dto;
+
+public record JobPostingResponse(
+        Long id,
+        String title,
+        String category,
+        String salaryInfo,
+        String location,
+        String preferredAgeGroup,
+        String industry,
+        String brandName,
+        String workDays,
+        String workHours,
+        String recruitmentConditions,
+        String workRegion,
+        String detailedDescription
+) {
+}

--- a/src/main/java/com/example/GOLDNet/service/JobPostingService.java
+++ b/src/main/java/com/example/GOLDNet/service/JobPostingService.java
@@ -1,6 +1,7 @@
 package com.example.GOLDNet.service;
 
 import com.example.GOLDNet.domain.JobPosting;
+import com.example.GOLDNet.dto.JobPostingResponse;
 import com.example.GOLDNet.repository.JobPostingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,5 +41,26 @@ public class JobPostingService {
             jobPostingRepository.saveAll(jobPostingsToSave);
             System.out.println(jobPostingsToSave.size() + "개의 공고가 성공적으로 저장되었습니다.");
         }
+    }
+
+    public List<JobPostingResponse> getJobPostings() {
+        List<JobPosting> entities = jobPostingRepository.findAll();
+        return entities.stream()
+                .map(entity -> new JobPostingResponse(
+                        entity.getId(),
+                        entity.getTitle(),
+                        entity.getCategory(),
+                        entity.getSalaryInfo(),
+                        entity.getLocation(),
+                        entity.getPreferredAgeGroup(),
+                        entity.getIndustry(),
+                        entity.getBrandName(),
+                        entity.getWorkDays(),
+                        entity.getWorkHours(),
+                        entity.getRecruitmentConditions(),
+                        entity.getWorkRegion(),
+                        entity.getDetailedDescription()
+                ))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
- 크롤링한 job postings 정보를 프론트에 내리기 위한 api
```json
{
  "id": 1,
  "title": "어린이교통안전지킴이",
  "category": "정부지원일자리",
  "salaryInfo": "290000",
  "location": "강남구",
  "preferredAgeGroup": null,
  "industry": null,
  "brandName": null,
  "workDays": "10",
  "workHours": "3",
  "recruitmentConditions": "신청자격: 65세 이상 ...자. 국내 거주 외국민.",
  "workRegion": "수서종합사회복지관 2층 사무실",
  "detailedDescription": "노인공익활동사업1. 활동시간 : 총 10회(일 3시간) / 월 30시간 활동2. 활동비 : 월 29만원3. 신청자격 : 65세 이상 기초연금수급자, 직역연금수급자(...여 고득점자 순으로 통합 선발6. 준비서류 : 주민등록등본 1부, 기초연금수령확인서 1부, 통장사본 1부7. 신청장소 : 수서종합사회복지관 2층"
},
```
- 공고 자체에 내용이 없어서 null로 오는 정보가 많은 편이고 `detailedDescription` 은 프론트에서 파싱이 필요함