### PR TITLE
feat: resume 조회, 수정 api

### DIFF
--- a/src/main/java/com/example/GOLDNet/controller/ResumesController.java
+++ b/src/main/java/com/example/GOLDNet/controller/ResumesController.java
@@ -1,0 +1,26 @@
+package com.example.GOLDNet.controller;
+
+import com.example.GOLDNet.dto.ResumeUpsertRequest;
+import com.example.GOLDNet.dto.ResumeResponse;
+import com.example.GOLDNet.service.ResumeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/resumes")
+public class ResumesController {
+    private final ResumeService resumeService;
+
+    @GetMapping
+    public ResponseEntity<ResumeResponse> getResume(@RequestParam Long memberId){
+        return ResponseEntity.ok(resumeService.getResume(memberId));
+    }
+
+    @PostMapping
+    public ResponseEntity<ResumeResponse> upsertResume(@RequestParam Long memberId,
+                                                       @RequestBody ResumeUpsertRequest request){
+        return ResponseEntity.ok(resumeService.upsertResume(memberId, request));
+    }
+}

--- a/src/main/java/com/example/GOLDNet/domain/Resume.java
+++ b/src/main/java/com/example/GOLDNet/domain/Resume.java
@@ -2,9 +2,12 @@ package com.example.GOLDNet.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Table(name = "resumes")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Resume {
@@ -46,4 +49,40 @@ public class Resume {
 
     @Column(length = 255)
     private String preferentialTreatment; //취업 우대사항(국가유공자 자녀 등)
+
+
+    @Builder
+    public Resume(Member member, String education, String experience,
+                  String preferredConditions, String selfIntroduction, String skills,
+                  String strengths, String mbti, String licensesAbilities,
+                  String portfolioUrls, String preferentialTreatment) {
+        this.member = member;
+        this.education = education;
+        this.experience = experience;
+        this.preferredConditions = preferredConditions;
+        this.selfIntroduction = selfIntroduction;
+        this.skills = skills;
+        this.strengths = strengths;
+        this.mbti = mbti;
+        this.licensesAbilities = licensesAbilities;
+        this.portfolioUrls = portfolioUrls;
+        this.preferentialTreatment = preferentialTreatment;
+    }
+
+    // 업데이트 메서드
+    public void updateResume(String education, String experience, String preferredConditions,
+                             String selfIntroduction, String skills, String strengths,
+                             String mbti, String licensesAbilities, String portfolioUrls,
+                             String preferentialTreatment) {
+        this.education = education;
+        this.experience = experience;
+        this.preferredConditions = preferredConditions;
+        this.selfIntroduction = selfIntroduction;
+        this.skills = skills;
+        this.strengths = strengths;
+        this.mbti = mbti;
+        this.licensesAbilities = licensesAbilities;
+        this.portfolioUrls = portfolioUrls;
+        this.preferentialTreatment = preferentialTreatment;
+    }
 }

--- a/src/main/java/com/example/GOLDNet/dto/ResumeResponse.java
+++ b/src/main/java/com/example/GOLDNet/dto/ResumeResponse.java
@@ -1,0 +1,43 @@
+package com.example.GOLDNet.dto;
+
+import com.example.GOLDNet.domain.Resume;
+
+public record ResumeResponse(
+        Long memberId,
+        String education,
+        String experience,
+        String preferredConditions,
+        String selfIntroduction,
+        String skills,
+        String strengths,
+        String mbti,
+        String licensesAbilities,
+        String portfolioUrls,
+        String preferentialTreatment
+) {
+    // 이력서가 있을 때
+    public static ResumeResponse from(Long memberId, Resume resume) {
+        return new ResumeResponse(
+                memberId,
+                resume.getEducation(),
+                resume.getExperience(),
+                resume.getPreferredConditions(),
+                resume.getSelfIntroduction(),
+                resume.getSkills(),
+                resume.getStrengths(),
+                resume.getMbti(),
+                resume.getLicensesAbilities(),
+                resume.getPortfolioUrls(),
+                resume.getPreferentialTreatment()
+        );
+    }
+
+    // 이력서가 없을 때
+    public static ResumeResponse empty(Long memberId) {
+        return new ResumeResponse(
+                memberId,
+                null, null, null, null, null,
+                null, null, null, null, null
+        );
+    }
+}

--- a/src/main/java/com/example/GOLDNet/dto/ResumeUpsertRequest.java
+++ b/src/main/java/com/example/GOLDNet/dto/ResumeUpsertRequest.java
@@ -1,0 +1,15 @@
+package com.example.GOLDNet.dto;
+
+public record ResumeUpsertRequest(
+        String education,
+        String experience,
+        String preferredConditions,
+        String selfIntroduction,
+        String skills,
+        String strengths,
+        String mbti,
+        String licensesAbilities,
+        String portfolioUrls,
+        String preferentialTreatment
+) {
+}

--- a/src/main/java/com/example/GOLDNet/repository/MemberRepository.java
+++ b/src/main/java/com/example/GOLDNet/repository/MemberRepository.java
@@ -3,5 +3,8 @@ package com.example.GOLDNet.repository;
 import com.example.GOLDNet.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Integer> {
+    Optional<Member> findById(Long id);
 }

--- a/src/main/java/com/example/GOLDNet/repository/ResumeRepository.java
+++ b/src/main/java/com/example/GOLDNet/repository/ResumeRepository.java
@@ -1,7 +1,11 @@
 package com.example.GOLDNet.repository;
 
+import com.example.GOLDNet.domain.Member;
 import com.example.GOLDNet.domain.Resume;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ResumeRepository extends JpaRepository<Resume, Integer> {
+    Optional<Resume> findResumeByMember(Member member);
 }

--- a/src/main/java/com/example/GOLDNet/service/ResumeService.java
+++ b/src/main/java/com/example/GOLDNet/service/ResumeService.java
@@ -1,0 +1,72 @@
+package com.example.GOLDNet.service;
+
+import com.example.GOLDNet.domain.Member;
+import com.example.GOLDNet.domain.Resume;
+import com.example.GOLDNet.dto.ResumeUpsertRequest;
+import com.example.GOLDNet.dto.ResumeResponse;
+import com.example.GOLDNet.repository.MemberRepository;
+import com.example.GOLDNet.repository.ResumeRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeService {
+    private final ResumeRepository resumeRepository;
+    private final MemberRepository memberRepository;
+
+    public ResumeResponse getResume(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Member not found: " + memberId));
+        return resumeRepository.findResumeByMember(member)
+                .map(resume -> ResumeResponse.from(memberId, resume))
+                .orElse(ResumeResponse.empty(memberId));
+    }
+
+    public ResumeResponse upsertResume(Long memberId, ResumeUpsertRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Member not found: " + memberId));
+
+        Optional<Resume> existingResumeOpt = resumeRepository.findResumeByMember(member);
+
+        Resume resume;
+        if (existingResumeOpt.isPresent()) {
+            // 기존 이력서 업데이트
+            resume = existingResumeOpt.get();
+            resume.updateResume(
+                    request.education(),
+                    request.experience(),
+                    request.preferredConditions(),
+                    request.selfIntroduction(),
+                    request.skills(),
+                    request.strengths(),
+                    request.mbti(),
+                    request.licensesAbilities(),
+                    request.portfolioUrls(),
+                    request.preferentialTreatment()
+            );
+        } else {
+            // 새 이력서 생성
+            resume = Resume.builder()
+                    .member(member)
+                    .education(request.education())
+                    .experience(request.experience())
+                    .preferredConditions(request.preferredConditions())
+                    .selfIntroduction(request.selfIntroduction())
+                    .skills(request.skills())
+                    .strengths(request.strengths())
+                    .mbti(request.mbti())
+                    .licensesAbilities(request.licensesAbilities())
+                    .portfolioUrls(request.portfolioUrls())
+                    .preferentialTreatment(request.preferentialTreatment())
+                    .build();
+        }
+
+        Resume savedResume = resumeRepository.save(resume);
+
+        return ResumeResponse.from(memberId, savedResume);
+    }
+}


### PR DESCRIPTION
### 이력서 조회 API
`GET /resumes?memberId={memberId}`

- 특정 회원(memberId)의 이력서를 조회
- 이력서가 없으면 모든 필드가 null로 반환

### 이력서 등록/수정 API
`POST /resumes?memberId={memberId}`

- 특정 회원(memberId)의 이력서를 생성 / 수정
- 값이 채워지면 갱신, 없으면 새로 만듦